### PR TITLE
Adds .keycode command to diplay Curses value for key press

### DIFF
--- a/profanity.rb
+++ b/profanity.rb
@@ -1463,6 +1463,15 @@ key_action['send_command'] = proc {
 	end
 	if cmd =~ /^\.quit/
 		exit
+	elsif cmd =~ /^\.key/i
+		window = stream_handler['main']
+		window.add_string("* ")
+		window.add_string("* Waiting for key press...")
+		command_window.noutrefresh
+		Curses.doupdate
+		window.add_string("* Detected keycode: #{command_window.getch.to_s}")
+		window.add_string("* ")
+		Curses.doupdate
 	elsif cmd =~ /^\.copy/
 		# fixme
 	elsif cmd =~ /^\.fixcolor/i


### PR DESCRIPTION
I saw you mention a `.keycode` command in a PC forum thread, but I couldn't find it anywhere. I am trying to debug numpad input on my system and that seemed like an invaluable debugging tool, so I hacked up my own version.

I am a Curses noob, so there may be a better way to implement the output. I'm open to any suggestions if you have them.