### PR TITLE
Disregard custom progressbar display text

### DIFF
--- a/profanity.rb
+++ b/profanity.rb
@@ -1850,12 +1850,6 @@ Thread.new {
 								end
 							end
 						end
-					elsif xml =~ /^<progressBar id='(.*?)' value='[0-9]+' text='\1 (\-?[0-9]+)\/([0-9]+)'/
-						if window = progress_handler[$1]
-							if window.update($2.to_i, $3.to_i)
-								need_update = true
-							end
-						end
 					elsif xml =~ /^<progressBar id='encumlevel' value='([0-9]+)' text='(.*?)'/
 						if window = progress_handler['encumbrance']
 							if $2 == 'Overloaded'
@@ -1881,6 +1875,12 @@ Thread.new {
 								value = $1.to_i
 							end
 							if window.update(value, 110)
+								need_update = true
+							end
+						end
+					elsif xml =~ /^<progressBar id='(.*?)' value='[0-9]+' text='.*?\s+(\-?[0-9]+)\/([0-9]+)'/
+						if window = progress_handler[$1]
+							if window.update($2.to_i, $3.to_i)
 								need_update = true
 							end
 						end


### PR DESCRIPTION
 This defaults to the same value as the ID, but people can right click on it in SF and customize the display text (e.g. changing stamina to FACEPUNCHING ENERGY). This updates the regex progressbar bar handler to disregard the initial string that can vary. Previously people who customized this were unable to get progressbar updates for that stat.

https://discordapp.com/channels/226045346399256576/387286877327065108/589152191294734358